### PR TITLE
Remove unnecessary stack in tree.get

### DIFF
--- a/rbtree.js
+++ b/rbtree.js
@@ -476,10 +476,8 @@ proto.remove = function(key) {
 proto.get = function(key) {
   var cmp = this._compare
   var n = this.root
-  var stack = []
   while(n) {
     var d = cmp(key, n.key)
-    stack.push(n)
     if(d === 0) {
       return n.value
     }


### PR DESCRIPTION
We don't need to return an iterator in `get`, so building a stack is unnecessary. Makes `get` faster. 

Awesome library btw! I'm experimenting with balanced binary search trees in https://github.com/mourner/bbtree...
