### PR TITLE
Make search methods and their documentation consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,42 +117,46 @@ Removes the first item with `key` in the tree
 **Returns** A new tree with the given item removed if it exists
 
 ### `tree.find(key)`
-Returns an iterator pointing to the first item in the tree with `key`, otherwise `null`.
-
-### `tree.ge(key)`
-Find the first item in the tree whose key is `>= key`
+Finds the first item in the tree with `key`
 
 * `key` is the key to search for
 
-**Returns** An iterator at the given element.
+**Returns** An iterator at the given element or an empty iterator if the item was not found
+
+### `tree.ge(key)`
+Finds the first item in the tree whose key is `>= key`
+
+* `key` is the key to search for
+
+**Returns** An iterator at the given element or an empty iterator if the item was not found
 
 ### `tree.gt(key)`
 Finds the first item in the tree whose key is `> key`
 
 * `key` is the key to search for
 
-**Returns** An iterator at the given element
+**Returns** An iterator at the given element or an empty iterator if the item was not found
 
 ### `tree.lt(key)`
 Finds the last item in the tree whose key is `< key`
 
 * `key` is the key to search for
 
-**Returns** An iterator at the given element
+**Returns** An iterator at the given element or an empty iterator if the item was not found
 
 ### `tree.le(key)`
 Finds the last item in the tree whose key is `<= key`
 
 * `key` is the key to search for
 
-**Returns** An iterator at the given element
+**Returns** An iterator at the given element or an empty iterator if the item was not found
 
 ### `tree.at(position)`
 Finds an iterator starting at the given element
 
 * `position` is the index at which the iterator gets created
 
-**Returns** An iterator starting at position
+**Returns** An iterator starting at position or an empty iterator if the position is out of range
 
 ### `tree.begin`
 An iterator pointing to the first element in the tree

--- a/rbtree.js
+++ b/rbtree.js
@@ -448,11 +448,12 @@ proto.find = function(key) {
   var cmp = this._compare
   var n = this.root
   var stack = []
+  var last_ptr = 0
   while(n) {
     var d = cmp(key, n.key)
     stack.push(n)
     if(d === 0) {
-      return new RedBlackTreeIterator(this, stack)
+      last_ptr = stack.length
     }
     if(d <= 0) {
       n = n.left
@@ -460,16 +461,13 @@ proto.find = function(key) {
       n = n.right
     }
   }
-  return new RedBlackTreeIterator(this, [])
+  stack.length = last_ptr
+  return new RedBlackTreeIterator(this, stack)
 }
 
 //Removes item with key from tree
 proto.remove = function(key) {
-  var iter = this.find(key)
-  if(iter) {
-    return iter.remove()
-  }
-  return this
+  return this.find(key).remove()
 }
 
 //Returns the item at `key`


### PR DESCRIPTION
The library doesn't seem to be maintained anymore but I still try my luck. I use a modified version of this library in my projects and would like to get some (or preferably all) of those fixes, optimizations and features into upstream. Starting with this small fix.

1. Make documentation of search methods consistent with each other and the code.
2. Fix `find` method to always return an iterator to the first (left-most) matching item. Currently it returns iterator the the top-most element.

Closes #14