### PR TITLE
Properly handle `NaN` result from comparator function

### DIFF
--- a/rbtree.js
+++ b/rbtree.js
@@ -27,7 +27,19 @@ function recount(node) {
 }
 
 function RedBlackTree(compare, root) {
-  this._compare = compare
+  if (compare === defaultCompare) {
+    this._compare = compare
+  } else {
+    // Wrap the provided compare function to return `0` when comparator
+    // returns `NaN`, so that we have the same semantics as the comparator
+    // passed to `array.sort()`;
+    this._compare = function (a, b) {
+      const result = compare(a, b);
+      // `result !== result` is a way to check if `result` is NaN without
+      // requiring a polyfill for `Number.isNumber` in older runtimes
+      return result !== result ? 0 : result;
+    }
+  }
   this.root = root
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -477,3 +477,13 @@ tape("slab-sequence-2", function(t) {
 
   t.end()
 })
+
+tape("NaN-comparator", function(t) {
+  var u = makeTree(function(a,b) { return a - b });
+  u = u.insert(1, "one");
+  u = u.insert(Infinity, "Infinity one");
+  u = u.insert(Infinity, "Infinity two");
+  var i = u.find(Infinity);
+  t.equals(i.valid, true, "iterator is not valid -- did not find key Infinity");
+  t.end();
+});


### PR DESCRIPTION
Fixes #18 

Wraps user-supplied comparator function so that a result of `NaN` is converted to `0`. This allows internal comparisons (e.g., in `.find()`) to work properly.

Also adds a unit test that fails before the fix and passes after the fix.

More details on the problem and fix are in #18.